### PR TITLE
Fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out those modules for specific usage examples!
 
 ## What is a URL?
 
-A URL is defined by Tim Breners-Lee in [this document](https://tools.ietf.org/html/rfc3986). It is worth reading, but I will try to share some highlights. He shares an example like this:
+A URL is defined by Tim Berners-Lee in [this document](https://tools.ietf.org/html/rfc3986). It is worth reading, but I will try to share some highlights. He shares an example like this:
 
 ```
   https://example.com:8042/over/there?name=ferret#nose

--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -5,7 +5,7 @@ module Url.Builder exposing
   )
 
 
-{-| In [the URI spec](https://tools.ietf.org/html/rfc3986), Tim Breners-Lee
+{-| In [the URI spec](https://tools.ietf.org/html/rfc3986), Tim Berners-Lee
 says a URL looks like this:
 
 ```

--- a/src/Url/Parser.elm
+++ b/src/Url/Parser.elm
@@ -5,7 +5,7 @@ module Url.Parser exposing
   , parse
   )
 
-{-| In [the URI spec](https://tools.ietf.org/html/rfc3986), Tim Breners-Lee
+{-| In [the URI spec](https://tools.ietf.org/html/rfc3986), Tim Berners-Lee
 says a URL looks like this:
 
 ```

--- a/src/Url/Parser/Query.elm
+++ b/src/Url/Parser/Query.elm
@@ -3,7 +3,7 @@ module Url.Parser.Query exposing
   , map, map2, map3, map4, map5, map6, map7, map8
   )
 
-{-| In [the URI spec](https://tools.ietf.org/html/rfc3986), Tim Breners-Lee
+{-| In [the URI spec](https://tools.ietf.org/html/rfc3986), Tim Berners-Lee
 says a URL looks like this:
 
 ```


### PR DESCRIPTION
The referenced rfc3986 refers to him as `T. Berners-Lee`.