### PR TITLE
Add a function for parsing all remaining path segments.

### DIFF
--- a/src/Url/Parser.elm
+++ b/src/Url/Parser.elm
@@ -1,6 +1,6 @@
 module Url.Parser exposing
   ( Parser, string, int, s
-  , (</>), map, oneOf, top, custom
+  , (</>), map, oneOf, top, custom, remainder
   , (<?>), query
   , fragment
   , parse
@@ -23,7 +23,7 @@ This module is primarily for parsing the `path` part.
 @docs Parser, string, int, s
 
 # Path
-@docs (</>), map, oneOf, top, custom
+@docs (</>), map, oneOf, top, custom, remainder
 
 # Query
 @docs (<?>), query
@@ -154,6 +154,24 @@ custom tipe stringToSomething =
 
           Nothing ->
             []
+
+
+{-| Parse all remaining path segments as a `List String`.
+
+    blog : Parser (List String -> a) a
+    blog =
+      s "blog" </> remainder
+
+    -- /blog              ==>  Just []
+    -- /blog/hello        ==>  Just [ "hello" ]
+    -- /blog/hello/world  ==>  Just [ "hello", "world" ]
+    -- /foo/bar           ==>  Nothing
+-}
+remainder : Parser (List String -> a) a
+remainder =
+    Parser <|
+        \{ unvisited, params, frag, value } ->
+            [ State [] params frag (value unvisited) ]
 
 
 


### PR DESCRIPTION
Having an operation like this is useful for cases where you need to forward/process arbitrary requests for a certain path prefix. While there, make a tiny cleanup to the parser by removing an unused field in the parser state.

Fixes: #9