### PR TITLE
Support IPv6 literal

### DIFF
--- a/src/Url.elm
+++ b/src/Url.elm
@@ -163,21 +163,30 @@ chompBeforePath : Protocol -> String -> Maybe String -> Maybe String -> String -
 chompBeforePath protocol path params frag str =
   if String.isEmpty str || String.contains "@" str then
     Nothing
+  else if String.startsWith "[" str then
+      -- IPv6 literal enclosed in brackets
+      case String.indexes "]" str of
+          i :: [] ->
+              Just <| Url protocol (String.left (i + 1) str) (String.toInt (String.dropLeft (i + 2) str)) path params frag
+
+          _ ->
+              Nothing
+
   else
-    case String.indexes ":" str of
-      [] ->
-        Just <| Url protocol str Nothing path params frag
+      case String.indexes ":" str of
+          [] ->
+              Just <| Url protocol str Nothing path params frag
 
-      i :: [] ->
-        case String.toInt (String.dropLeft (i + 1) str) of
-          Nothing ->
-            Nothing
+          i :: [] ->
+              case String.toInt (String.dropLeft (i + 1) str) of
+                  Nothing ->
+                      Nothing
 
-          port_ ->
-            Just <| Url protocol (String.left i str) port_ path params frag
+                  port_ ->
+                      Just <| Url protocol (String.left i str) port_ path params frag
 
-      _ ->
-        Nothing
+          _ ->
+              Nothing
 
 
 {-| Turn a [`Url`](#Url) into a `String`.


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc3986#section-3.2.2 for any URL the IPv6 literal must be enclosed in square brackets.

This implementation assumes anything remaining after the brackets is the port.

**Valid URLs**
``` elm
> Url.fromString "http://[2001:db8:a0b:12f0::1]/index.html"
Just { fragment = Nothing, host = "[2001:db8:a0b:12f0::1]", path = "/index.html", port_ = Nothing, protocol = Http, query = Nothing }
> Url.fromString "http://[2001:db8:a0b:12f0::1]:80/index.html"
Just { fragment = Nothing, host = "[2001:db8:a0b:12f0::1]", path = "/index.html", port_ = Just 80, protocol = Http, query = Nothing }
```

**Rejected URLs**
``` elm
> Url.fromString "http://[/index.html" -- missing ]
Nothing
```

This fixes https://github.com/elm/url/issues/12