### PR TITLE
New Value for QueryParameter: none

### DIFF
--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -21,7 +21,7 @@ This module helps you create these!
 @docs absolute, relative, crossOrigin, custom, Root
 
 # Queries
-@docs QueryParameter, string, int, toQuery
+@docs QueryParameter, string, int, none, toQuery
 
 -}
 
@@ -193,7 +193,9 @@ int : String -> Int -> QueryParameter
 int key value =
   QueryParameter (Url.percentEncode key) (String.fromInt value)
 
-{-| Equivalent to Html.none, this does nothing. Adds nothing to a query
+{-| Equivalent to Html.none, this does nothing.
+Adds nothing to a query.
+This is useful for the generation of dynamic urls.
 
   absolute ["products"] [ string "search" "hat", none]
   == absolute ["products"] [ string "search" "hat"]

--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -1,6 +1,6 @@
 module Url.Builder exposing
   ( absolute, relative, crossOrigin, custom, Root(..)
-  , QueryParameter, string, int, toQuery
+  , QueryParameter, string, int, none, toQuery
   )
 
 

--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -193,6 +193,14 @@ int : String -> Int -> QueryParameter
 int key value =
   QueryParameter (Url.percentEncode key) (String.fromInt value)
 
+{-| Equivalent to Html.none, this does nothing. Adds nothing to a query
+
+  absolute ["products"] [ string "search" "hat", none]
+  == absolute ["products"] [ string "search" "hat"]
+
+-}
+none : QueryParameter
+none = QueryParameter "" ""
 
 {-| Convert a list of query parameters to a percent-encoded query. This
 function is used by `absolute`, `relative`, etc.
@@ -211,12 +219,13 @@ function is used by `absolute`, `relative`, etc.
 -}
 toQuery : List QueryParameter -> String
 toQuery parameters =
-  case parameters of
+  let parameters_ = List.filter ((/=) none) parameters
+  in case parameters_ of
     [] ->
       ""
 
     _ ->
-      "?" ++ String.join "&" (List.map toQueryPair parameters)
+      "?" ++ String.join "&" (List.map toQueryPair parameters_)
 
 
 toQueryPair : QueryParameter -> String

--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -221,12 +221,12 @@ function is used by `absolute`, `relative`, etc.
 -}
 toQuery : List QueryParameter -> String
 toQuery parameters =
-  case parameters_ of
+  case parameters of
     [] ->
       ""
 
     _ ->
-      "?" ++ String.join "&" (List.map toQueryPair parameters_)
+      "?" ++ String.join "&" (List.map toQueryPair parameters)
 
 
 toQueryPair : QueryParameter -> String

--- a/src/Url/Builder.elm
+++ b/src/Url/Builder.elm
@@ -221,8 +221,7 @@ function is used by `absolute`, `relative`, etc.
 -}
 toQuery : List QueryParameter -> String
 toQuery parameters =
-  let parameters_ = List.filter ((/=) none) parameters
-  in case parameters_ of
+  case parameters_ of
     [] ->
       ""
 
@@ -232,4 +231,6 @@ toQuery parameters =
 
 toQueryPair : QueryParameter -> String
 toQueryPair (QueryParameter key value) =
-  key ++ "=" ++ value
+  if QueryParameter key value == none
+    then ""
+    else key ++ "=" ++ value


### PR DESCRIPTION
Many packages expose a none value, such as `Html.none` or `Cmd.none`.

Though these values do not do anything, they are useful,
especially if you use `if ... else` or `case ... of` and some cases
should do nothing.

I think it could be useful to introduce such a value to do nothing for the Url.Builder.QueryParameter type
I write some more general functions for requests that cover several cases and 
I thus need to use many `case ... of` statements and it would make this very easy.

Currently I am working with list concats and produce code
that is anything but nice on the eyes.

# Implementation
With this PR I implement just this feature:
Url.Builder exposes a `none : QueryParameter` value,
which results in an empty Query string.
