### PR TITLE
Replace the note about query-only parsers

### DIFF
--- a/src/Url/Parser.elm
+++ b/src/Url/Parser.elm
@@ -316,8 +316,7 @@ those into normal parsers.
     -- s "blog" <?> Query.string "search"
     -- s "blog" </> query (Query.string "search")
 
-This may be handy if you need query parameters but are not parsing any path
-segments.
+**Note:** parsers created with just `query` and no path segments expect an empty path.
 -}
 query : Query.Parser query -> Parser (query -> a) a
 query (Q.Parser queryParser) =


### PR DESCRIPTION
Parsing just a query requires additional steps.

Current text suggests a parser created with `Parser.query` ignores the path, but it doesn't, and it trips people up: see https://github.com/elm/url/issues/36 and https://github.com/elm/url/issues/17.